### PR TITLE
Ridefinizione della macro \vec e correzione della formattazione per la dimostrazione sulle matrici stocastiche

### DIFF
--- a/src/preambolo.sty
+++ b/src/preambolo.sty
@@ -21,6 +21,8 @@
 \usepackage{amsmath}
 \usepackage{amssymb}
 
+\usepackage{bm}
+
 \usepackage{amsthm}
 \theoremstyle{plain}
 \newtheorem{thm}{Teorema}
@@ -50,6 +52,7 @@
 \newcommand{\card}[1]{\left|#1\right|}
 \newcommand{\dtv}{d_{\mathrm{TV}}}
 \newcommand{\ceil}[1]{\left\lceil #1 \right\rceil}
+\renewcommand{\vec}[1]{\bm{#1}}
 
 \renewcommand{\epsilon}{\varepsilon}
 \renewcommand{\emptyset}{\varnothing}

--- a/src/stocautov.tex
+++ b/src/stocautov.tex
@@ -21,13 +21,13 @@
 	Sia $A\in\Rp^{k\times k}$ stocastica e $\mu$ autovalore di $A$. Allora $\abs{\mu}\le 1$.
 \end{thm}
 \begin{proof}
-	Sia $v$ autovettore sinistro di $A$ rispetto a $\mu$, ossia $v\ne0\land v\tra A$.
+	Sia $\vec{v}$ autovettore sinistro di $A$ rispetto a $\mu$, ossia $\vec{v}\ne0\land \vec{v}\tra A$.
 	\begin{align*}
-		\abs{\mu}\cdot\norm{v} & = \abs{\mu}\sum_{j=1}^k\abs{v_j} = \sum_{j=1}^k\abs {\mu v_j}                                 \\
-		                       & = \sum_{j=1}^k\abs {(\mu v)_j} = \sum_{j=1}^k\abs {(v\tra A)_j}                               \\
+		\abs{\mu}\cdot\norm{\vec{v}}_1 & = \abs{\mu}\sum_{j=1}^k\abs{v_j} = \sum_{j=1}^k\abs {\mu v_j}                                 \\
+		                       & = \sum_{j=1}^k\abs {(\mu \vec{v})_j} = \sum_{j=1}^k\abs {(\vec{v}\tra A)_j}                               \\
 		                       & = \sum_{j=1}^k\abs {\sum_{i=1}^k v_i a_{i,j}}                                                 \\
 		                       & \le \sum_{j=1}^k \sum_{i=1}^k \abs{v_i} a_{i,j} = \sum_{i=1}^k \abs{v_i} \sum_{j=1}^k a_{i,j} \\
-		                       & = \sum_{i=1}^k \abs{v_i} = \norm{v}
+		                       & = \sum_{i=1}^k \abs{v_i} = \norm{\vec{v}}_1
 	\end{align*}
 	Da cui, essendo $v\neq 0$:
 	\begin{equation*}

--- a/src/stocautov.tex
+++ b/src/stocautov.tex
@@ -21,7 +21,7 @@
 	Sia $A\in\Rp^{k\times k}$ stocastica e $\mu$ autovalore di $A$. Allora $\abs{\mu}\le 1$.
 \end{thm}
 \begin{proof}
-	Sia $\vec{v}$ autovettore sinistro di $A$ rispetto a $\mu$, ossia $\vec{v}\ne0\land \vec{v}\tra A$.
+	Sia $\vec{v}$ autovettore sinistro di $A$ rispetto a $\mu$, ossia $\vec{v}\ne\vec{0}\land \vec{v}\tra A$.
 	\begin{align*}
 		\abs{\mu}\cdot\norm{\vec{v}}_1 & = \abs{\mu}\sum_{j=1}^k\abs{v_j} = \sum_{j=1}^k\abs {\mu v_j}                                 \\
 		                       & = \sum_{j=1}^k\abs {(\mu \vec{v})_j} = \sum_{j=1}^k\abs {(\vec{v}\tra A)_j}                               \\
@@ -29,7 +29,7 @@
 		                       & \le \sum_{j=1}^k \sum_{i=1}^k \abs{v_i} a_{i,j} = \sum_{i=1}^k \abs{v_i} \sum_{j=1}^k a_{i,j} \\
 		                       & = \sum_{i=1}^k \abs{v_i} = \norm{\vec{v}}_1
 	\end{align*}
-	Da cui, essendo $v\neq 0$:
+	Da cui, essendo $\vec{v}\neq \vec{0}$:
 	\begin{equation*}
 		\abs{\mu}\leq 1 \qedhere
 	\end{equation*}


### PR DESCRIPTION
Ridefinizione della macro \vec

modifica della formattazione degli autovettori per la seconda dimostrazione (messi tutti in bold + italic usando \bm), messo in bold anche il vettore 0.
Aggiunto il pedice 1 a tutte le norme per indicare la norma L1